### PR TITLE
Add GPU debugging output to workbench example

### DIFF
--- a/examples/llmcompressor/workbench_example.ipynb
+++ b/examples/llmcompressor/workbench_example.ipynb
@@ -32,7 +32,10 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "use_gpu = torch.cuda.is_available()"
+    "use_gpu = torch.cuda.is_available()\n",
+    "print(f\"GPU acceleration available: {use_gpu}\")\n",
+    "if not use_gpu:\n",
+    "    print(\"Running in CPU-only mode - operations will be slower and use abbreviated datasets\")"
    ]
   },
   {


### PR DESCRIPTION
Add GPU debugging information to the llmcompressor workbench example notebook to help users understand whether GPU acceleration is available.

This enhancement helps users verify that their GPU setup is working correctly and understand why they might be experiencing slower performance or abbreviated datasets.

Fixes #4