### PR TITLE
Add mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,50 @@
+pull_request_rules:
+  - name: auto-merge
+    description: >
+      Automatic merge of PRs to main on approval with passing checks
+    conditions:
+      - "#approved-reviews-by>=1"
+      - check-success=Linting and Formatting
+      - check-success=Secret Scanning
+      - "#changes-requested-reviews-by=0"
+      - -draft
+      - -conflict
+      - label!=do-not-merge
+      - label!=needs-rebase
+
+    actions:
+      merge:
+        method: squash
+        commit_message_template: |
+          {{ title }} (#{{ number }})
+
+          {{ body }}
+
+          {% for user in approved_reviews_by %}
+          Approved-by: {{ user }}
+          {% endfor %}
+
+  - name: ping author on conflicts and add 'needs-rebase' label
+    conditions:
+      - conflict
+      - -closed
+    actions:
+      label:
+        add:
+          - needs-rebase
+      comment:
+        message: >
+          This pull request has merge conflicts that must be resolved before it
+          can be merged. @{{author}} please rebase it.
+          https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork
+
+  - name: remove 'needs-rebase' label when conflict is resolved
+    conditions:
+      - -conflict
+      - -closed
+    actions:
+      label:
+        remove:
+          - needs-rebase
+
+


### PR DESCRIPTION
Added Mergify configuration to automate merging of approved pull requests and improve conflict handling.

Auto‑merge rule
Automatically squash‑merges PRs once:
- At least one review has approved: #approved-reviews-by>=1
- No reviewer has requested changes: #changes-requested-reviews-by=0
- The PR is not a draft and not in conflict (-draft, -conflict)
- The PR is not labeled do-not-merge or needs-rebase
- CI checks Linting and Formatting and Secret Scanning have succeeded
