### PR TITLE
Configure nbstripout pre-commit hook to strip notebook metadata

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -46,5 +46,3 @@ pull_request_rules:
       label:
         remove:
           - needs-rebase
-
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,21 @@
 # Run manually: pre-commit run --all-files
 
 repos:
+  # Strip outputs from Jupyter notebooks
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.8.2
+    hooks:
+      - id: nbstripout
+        args:
+          - --keep-id
+          - --drop-empty-cells
+          - --extra-keys
+          - >-
+            metadata.widgets
+            cell.metadata.execution
+            cell.metadata.scrolled
+            cell.metadata.collapsed
+
   # Python linting and formatting with Ruff
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,30 @@ markdownlint --fix .
 pre-commit run --all-files
 ```
 
+## Working with Jupyter Notebooks
+
+This repository uses `nbstripout` (via pre-commit) to automatically strip outputs and some metadata from Jupyter notebooks before they are committed. This keeps diffs small and avoids committing large or transient outputs.
+
+### Preserving Specific Cell Outputs
+
+In some cases, you may need to keep the output of a particular cell (for example, a reference plot or a summary table that is important for readers). To **exclude a cell's output from being stripped by `nbstripout`**, mark the cell with special metadata:
+
+- **Using a cell tag (recommended)**
+  - Select the cell
+  - In the right sidebar, open the **Tags** panel
+  - Add the tag `keep_output`
+
+- **Using cell metadata directly**
+  - Open the cell metadata editor and add:
+
+    ```json
+    {
+      "keep_output": true
+    }
+    ```
+
+Cells tagged with `keep_output` (or with metadata `"keep_output": true`) will keep their outputs even when the `nbstripout` pre-commit hook runs. All other cells will have their outputs stripped as usual.
+
 ## Code Quality Standards
 
 All contributions must pass the automated code quality checks before being merged. This includes:

--- a/examples/fine-tuning/training-hub/sft/sft.ipynb
+++ b/examples/fine-tuning/training-hub/sft/sft.ipynb
@@ -904,14 +904,6 @@
     "\n",
     "print(\"[CLEANUP] Torch resources freed, CUDA cache cleared.\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f3ca8b87-07d0-4bc0-b9d4-6e7b758f30cc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/knowledge-tuning/01_Base_Model_Evaluation/Base_Model_Evaluation.ipynb
+++ b/examples/knowledge-tuning/01_Base_Model_Evaluation/Base_Model_Evaluation.ipynb
@@ -148,27 +148,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "3abfb288",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MAX_NEW_TOKENS: 256\n",
-      "DO_SAMPLE: True\n",
-      "TEMPERATURE: 0.7\n",
-      "TOP_P: 0.9\n",
-      "✅ LLM sampling parameters defined\n",
-      "\n",
-      "📊 Using Meta's recommended Llama sampling settings:\n",
-      "  • Temperature 0.6 for balanced creativity/consistency\n",
-      "  • Top-p 0.9 for good token diversity\n",
-      "  • Stop on both EOS and <|eot_id|> tokens\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "################################################################################\n",
     "# 🎯 Sampling/Generation Parameters                                            #\n",

--- a/examples/knowledge-tuning/02_Data_Processing/Data_Processing.ipynb
+++ b/examples/knowledge-tuning/02_Data_Processing/Data_Processing.ipynb
@@ -331,9 +331,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9ddc7c2b-6957-44c1-811b-2e950a540e74",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
@@ -429,12 +427,6 @@
     "- The seed_data.jsonl file is now ready for the knowledge tuning pipeline.\n",
     "- You can now refer to the [knowledge generation](../03_Knowledge_Generation/Knowledge_Generation.ipynb) notebook"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c6af0f6e",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/knowledge-tuning/03_Knowledge_Generation/Knowledge_Generation.ipynb
+++ b/examples/knowledge-tuning/03_Knowledge_Generation/Knowledge_Generation.ipynb
@@ -448,11 +448,6 @@
     "   - Combine and curate these datasets to prepare your final training data.\n",
     "   - For detailed guidance on post-processing, mixing, and formatting the data for model training (including conversion to messages format), please refer to [knowledge_mixing.ipynb](../04_Knowledge_Mixing/Knowledge_Mixing.ipynb)."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/knowledge-tuning/04_Knowledge_Mixing/Knowledge_Mixing.ipynb
+++ b/examples/knowledge-tuning/04_Knowledge_Mixing/Knowledge_Mixing.ipynb
@@ -513,12 +513,6 @@
     "Combined the datasets are now ready for model training.\n",
     "Continue to the [Model Training](../05_Model_Training/Model_Training.ipynb) notebook to fine-tune your model using the prepared datasets."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "68753cd1",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/llmcompressor/workbench_example.ipynb
+++ b/examples/llmcompressor/workbench_example.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,22 +125,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| Tasks  |Version|Filter|n-shot|    Metric     |   | Value |   |Stderr|\n",
-      "|--------|------:|------|-----:|---------------|---|------:|---|------|\n",
-      "|wikitext|      2|none  |     0|bits_per_byte  |↓  | 0.7586|±  |   N/A|\n",
-      "|        |       |none  |     0|byte_perplexity|↓  | 1.6918|±  |   N/A|\n",
-      "|        |       |none  |     0|word_perplexity|↓  |16.6397|±  |   N/A|\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(make_table(results))"
    ]
@@ -162,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,22 +262,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "| Tasks  |Version|Filter|n-shot|    Metric     |   | Value |   |Stderr|\n",
-      "|--------|------:|------|-----:|---------------|---|------:|---|------|\n",
-      "|wikitext|      2|none  |     0|bits_per_byte  |↓  | 0.7497|±  |   N/A|\n",
-      "|        |       |none  |     0|byte_perplexity|↓  | 1.6814|±  |   N/A|\n",
-      "|        |       |none  |     0|word_perplexity|↓  |16.0972|±  |   N/A|\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(make_table(results))"
    ]


### PR DESCRIPTION
Adds `nbstripout` configuration to the pre-commit hooks to automatically clean Jupyter notebooks of environment-specific metadata, execution outputs, and UI preferences while preserving cell IDs. This ensures cleaner git diffs, smaller notebooks, and fewer merge conflicts.

## Related Tickets


- [RHAIENG-1698](https://issues.redhat.com/browse/RHAIENG-1698)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
