### PR TITLE
Fix: deleted autoselect from serving runtime config

### DIFF
--- a/examples/automl/churn_prediction_tutorial.md
+++ b/examples/automl/churn_prediction_tutorial.md
@@ -298,8 +298,6 @@ spec:
   supportedModelFormats:
     - name: autogluon
       version: "1"
-      autoSelect: true
-      priority: 2
   protocolVersions:
     - v1
     - v2


### PR DESCRIPTION
Provide a short summary in the Title above. Examples of good PR titles:

## Description

There was an issue when deploying two AutoGluon models in the cluster. The deployment failed with the following error:

"admission webhook "servingruntime.kserve-webhook-server.validator" denied the request: same priority assigned for the model format autogluon in the servingruntimes deploymentwithv2protocolresponsefixed and test-deployment-name in namespace customer-churn-ml"

This happened because two or more ServingRuntimes for the `autogluon` model format existed with the same priority, so KServe could not determine which runtime should be selected.

Since the user already explicitly specifies which ServingRuntime should be used for a given deployment, the `autoSelect` field was removed from the YAML configuration. If not specified, this field defaults to `false`. With `autoSelect` disabled, the `priority` field is no longer needed, so it was removed as well.

Fixes # (issue)

- removed the `autoSelect` field from the ServingRuntime YAML
- removed the `priority` field from the ServingRuntime YAML

## Related Tickets

Related jira tickets here:
- https://issues.redhat.com/browse/RHAIENG-3473
