### PR TITLE
Fix: resolve KFP dependency conflict in knowledge-tuning pipeline

### DIFF
--- a/examples/knowledge-tuning/Kubeflow_Pipeline/README.md
+++ b/examples/knowledge-tuning/Kubeflow_Pipeline/README.md
@@ -107,8 +107,8 @@ Source repository: `red-hat-data-services/pipelines-components`
 
    Run the following commands to install these required packages:
 
-   - `kfp==2.15.2`
-   - `kfp-kubernetes>=2.15.2`
+   - `kfp>=2.16.1`
+   - `kfp-kubernetes>=2.16.1`
    - `kfp-components @ git+https://github.com/red-hat-data-services/pipelines-components@main`
 
    ```bash

--- a/examples/knowledge-tuning/Kubeflow_Pipeline/pyproject.toml
+++ b/examples/knowledge-tuning/Kubeflow_Pipeline/pyproject.toml
@@ -5,7 +5,7 @@ description = "Kubeflow pipeline for the Knowledge Tuning workflow"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "kfp-kubernetes>=2.15.2",
-    "kfp==2.15.2",
+    "kfp-kubernetes>=2.16.1",
+    "kfp>=2.16.1",
     "kfp-components @ git+https://github.com/red-hat-data-services/pipelines-components@main",
 ]


### PR DESCRIPTION
## Summary

- Bump `kfp` and `kfp-kubernetes` from `2.15.2` to `>=2.16.1` in the knowledge-tuning Kubeflow pipeline
- Resolves a pip dependency conflict where `kfp-components@main` requires `kfp>=2.16.1` while the pipeline pinned `kfp==2.15.2`
- Fixes the failing `Validation & Tests` CI job (`test_venv_builds_cleanly` in `tests/validation/test_pyproject_toml.py`)

## Test plan

- [x] Verified locally: `pip install --dry-run -e examples/knowledge-tuning/Kubeflow_Pipeline` resolves cleanly to `kfp-2.16.1`, `kfp-kubernetes-2.16.1`, and `kfp-components-1.11.0`
- [ ] CI `Notebook Tests` workflow passes